### PR TITLE
Unify Inertia Object Handling and Physical Compliance

### DIFF
--- a/phobos/definitions/defaultMaterials.yml
+++ b/phobos/definitions/defaultMaterials.yml
@@ -64,3 +64,8 @@ materials:
         specular: [1, 1, 1]
         alpha: 1.0
         diffuse_intensity: 1.0
+    phobos_error:
+        diffuse: [1, 0, 0]
+        specular: [1, 1, 1]
+        alpha: 1.0
+        diffuse_intensity: 1.0

--- a/phobos/model/inertia.py
+++ b/phobos/model/inertia.py
@@ -59,7 +59,6 @@ def createInertial(parentname, inertialdict, parentobj=None, effectiveParent = N
 
     try:
         origin = mathutils.Vector(inertialdict['pose']['translation'])
-        print(origin)
     except KeyError:
         origin = mathutils.Vector()
 
@@ -78,23 +77,15 @@ def createInertial(parentname, inertialdict, parentobj=None, effectiveParent = N
     bpy.ops.object.transform_apply(scale=True)
     if parentobj:
         inertialobject.matrix_world = parentobj.matrix_world
-        parent = parentobj if parentobj.phobostype in ['link', 'visual', 'collision'] else parentobj.parent
+        parent = parentobj if parentobj.phobostype == 'link' else parentobj.parent
         sUtils.selectObjects((inertialobject, parent), clear=True, active=1)
-        if parentobj.phobostype == 'link':
-            # Create the inertial object relative to the link / joint
-            bpy.ops.object.parent_set(type='BONE_RELATIVE')
-            inertialobject.matrix_local = mathutils.Matrix.Translation(origin)
-        else:
-            # Create the inertial object relative to its parent
-            bpy.ops.object.parent_set(type='OBJECT')
-            inertialobject.matrix_local = mathutils.Matrix.Translation(mathutils.Vector())
 
-
+        # Create the inertial object relative to the link / joint
+        bpy.ops.object.parent_set(type='BONE_RELATIVE')
+        inertialobject.matrix_local = mathutils.Matrix.Translation(origin)
         sUtils.selectObjects((inertialobject,), clear=True, active=0)
         bpy.ops.object.transform_apply(scale=True)  # force matrix_world update
-    if effectiveParent:
-        # Add the effective parent
-        inertialobject['effectiveParent'] = effectiveParent
+
     # set properties
     for prop in ('mass', 'inertia'):
         inertialobject[prop] = inertialdict[prop]

--- a/phobos/model/inertia.py
+++ b/phobos/model/inertia.py
@@ -451,6 +451,7 @@ def checkMass(mass):
     """
     return mass > 0.
 
+
 def checkInertia(inertia):
     """ Checks if the inertia of an object leads to positive definite inertia matrix.
 
@@ -486,7 +487,6 @@ def checkInertia(inertia):
         return consistency
     else:
         return False
-
 
 
 def inertiaListToMatrix(il):
@@ -573,6 +573,31 @@ def getInertiaRelevantObjects(link, selected_only=False):
     return inertiaobjects
 
 
+def getInertiaChildren(link, selected_only = False):
+    """Returns a list of the inertia objects which are children of a link.
+
+    Args:
+     link(bpy_types.Object): The link you want to gather the inertia relevant objects for.
+     selected_only(bool, optional): return only relevant objects which are selected (Default value = False)
+
+   Returns:
+     list
+
+    """
+
+    # Get the inertia objects
+    inertiaobjects = sUtils.getImmediateChildren(link, ('inertial'), selected_only)
+
+    # Get the visuals and collisions
+    viscols = getInertiaRelevantObjects(link, selected_only)
+    # Iterate over the objects and get the inertia objects
+    for obj in viscols:
+        # Add inertia objects to the list
+        inertiaobjects += sUtils.getImmediateChildren(obj, ('inertial'), selected_only)
+
+    return inertiaobjects
+
+
 def fuseInertiaData(inertials):
     """Computes combined mass, center of mass and inertia given an iterable of inertial objects.
 
@@ -611,6 +636,12 @@ def fuseInertiaData(inertials):
     else:
         log("No inertial found to fuse.", "DEBUG")
         return None, None, None
+
+
+def fuseLinkInertia(link, inertials):
+    # TODO Placeholder
+    return None
+
 
 
 def combine_com_3x3(objects):

--- a/phobos/model/inertia.py
+++ b/phobos/model/inertia.py
@@ -438,9 +438,11 @@ def inertiaListToMatrix(il):
     """
     if type(il) == mathutils.Matrix:
         return il
+
     inertia = [[il[0], il[1], il[2]],
-               [0.0, il[3], il[4]],
-               [0.0, 0.0, il[5]]]
+               [il[1], il[3], il[4]],
+               [il[2], il[4], il[5]]]
+
     return mathutils.Matrix(inertia)
 
 

--- a/phobos/model/models.py
+++ b/phobos/model/models.py
@@ -150,10 +150,16 @@ def deriveLink(linkobj):
     props['approxcollision'] = []
 
     # add inertial information to link
-    inertialobjs = [obj for obj in linkobj.children if obj.phobostype == 'inertial'
-                   and 'inertial/inertia' in obj]
+    #inertialobjs = [obj for obj in linkobj.children if obj.phobostype == 'inertial'
+    #               and 'inertial/inertia' in obj]
+    inertialobjs = inertiamodel.getInertiaChildren(linkobj)
+
     if len(inertialobjs) == 1:
         props['inertial'] = deriveDictEntry(inertialobjs[0])
+        print(props['inertial'])
+    elif len(inertialobjs) > 1:
+        mass, com, inertia = inertiamodel.fuseInertiaData(inertialobjs)
+        print(mass, com, inertia)
     else:
         log("No valid inertial data for link " + props['name'], "WARNING")
     return props
@@ -192,8 +198,7 @@ def deriveFullLinkInformation(obj):
     for visualobj in visualObjects:
         visualDict[visualobj.name] = visualobj
     props["visual"] = visualDict
-    inertialObjects = sUtils.getImmediateChildren(
-        obj, phobostypes=('inertial'), include_hidden=True)
+    inertialObjects = inertiamodel.getInertiaChildren(obj)
     inertialDict = {}
     for inertialobj in inertialObjects:
         inertialDict[inertialobj.name] = inertialobj
@@ -328,7 +333,7 @@ def deriveInertial(obj):
     """
     try:
         props = initObjectProperties(obj, phobostype='inertial')
-        props['inertia'] = list(map(float, obj['inertial/inertia']))
+        props['inertia'] = list(map(float, obj['inertia']))
         props['pose'] = deriveObjectPose(obj)
     except KeyError as e:
         log("Missing data in inertial object " + obj.name + str(e), "ERROR")
@@ -726,8 +731,7 @@ def loadPose(modelname, posename):
 
     Args:
       modelname(str): The model's name.
-      posename(str.
-:return Nothing.): The name the pose is stored under.
+      posename(str): The name the pose is stored under.
 
     Returns:
 
@@ -962,7 +966,7 @@ def deriveModelDictionary(root, name='', objectlist=[]):
             model['motors'][motordict['name']] = motordict
 
     # combine inertia if certain objects are left out, and overwrite it
-    inertials = (i for i in objectlist if i.phobostype == 'inertial' and "inertial/inertia" in i)
+    inertials = (i for i in objectlist if i.phobostype == 'inertial' and "inertia" in i)
     editlinks = {}
     for i in inertials:
         if i.parent not in linklist:
@@ -995,7 +999,7 @@ def deriveModelDictionary(root, name='', objectlist=[]):
         if obj.phobostype in ['visual', 'collision']:
             props = deriveDictEntry(obj)
             parentname = nUtils.getObjectName(sUtils.getEffectiveParent(obj, ignore_selection=bool(objectlist)))
-            print(parentname, obj, props)
+            #print(parentname, obj, props)
             model['links'][parentname][obj.phobostype][nUtils.getObjectName(obj)] = props
         elif obj.phobostype == 'approxsphere':
             props = deriveDictEntry(obj)

--- a/phobos/model/models.py
+++ b/phobos/model/models.py
@@ -156,10 +156,14 @@ def deriveLink(linkobj):
 
     if len(inertialobjs) == 1:
         props['inertial'] = deriveDictEntry(inertialobjs[0])
-        print(props['inertial'])
-    elif len(inertialobjs) > 1:
-        mass, com, inertia = inertiamodel.fuseInertiaData(inertialobjs)
-        print(mass, com, inertia)
+        
+    # TODO Check if needed
+    #elif len(inertialobjs) > 1:
+    #    print('More! @ link {}'.format(linkobj.name))
+    #    mass, com, inertia = inertiamodel.fuseInertiaData(inertialobjs)
+    #    props['inertial'] =
+    #    print(mass, com, inertia)
+
     else:
         log("No valid inertial data for link " + props['name'], "WARNING")
     return props
@@ -333,6 +337,7 @@ def deriveInertial(obj):
     """
     try:
         props = initObjectProperties(obj, phobostype='inertial')
+        props['mass'] = obj['mass']
         props['inertia'] = list(map(float, obj['inertia']))
         props['pose'] = deriveObjectPose(obj)
     except KeyError as e:
@@ -968,6 +973,7 @@ def deriveModelDictionary(root, name='', objectlist=[]):
     # combine inertia if certain objects are left out, and overwrite it
     inertials = (i for i in objectlist if i.phobostype == 'inertial' and "inertia" in i)
     editlinks = {}
+
     for i in inertials:
         if i.parent not in linklist:
             realparent = sUtils.getEffectiveParent(i, ignore_selection=bool(objectlist))
@@ -977,6 +983,7 @@ def deriveModelDictionary(root, name='', objectlist=[]):
                     editlinks[parentname].append(i)
                 else:
                     editlinks[parentname] = [i]
+
     for linkname in editlinks:
         inertials = editlinks[linkname]
         try:

--- a/phobos/operators/editing.py
+++ b/phobos/operators/editing.py
@@ -617,7 +617,7 @@ class SmoothenSurfaceOperator(Operator):
 class CreateInertialOperator(Operator):
     """Create inertial object(s) from collision/visual objects of a link"""
     bl_idname = "phobos.create_inertials"
-    bl_label = "Create inertial objects"
+    bl_label = "Create Inertial Object(s)"
     bl_options = {'REGISTER', 'UNDO'}
 
     def getInertials(self, context, link=None):

--- a/phobos/operators/editing.py
+++ b/phobos/operators/editing.py
@@ -514,114 +514,114 @@ class SmoothenSurfaceOperator(Operator):
         ob = context.active_object
         return ob is not None and ob.mode == 'OBJECT' and len(context.selected_objects) > 0
 
+# OLD CODE
+#class CreateLinkInertialOperator(Operator):
+#    """Create inertial object(s) for link(s)"""
+#    bl_idname = "phobos.create_link_inertials"
+#    bl_label = "Create link inertia"
+#    bl_options = {'REGISTER', 'UNDO'}
+#
+#    def getLinkInertials(self, context, link=None):
+#        """Returns all link inertials of the selected links (in the current
+#        context) or of the specified link.
+#
+#        Args:
+#          context: Blender context
+#          link: the link of which to find the inertials (optional) (Default value = None)
+#
+#        Returns:
+#          dictionary of links with list of Blender objects or just a list.
+#
+#        """
+#        linklist = [obj for obj in context.selected_objects if obj.phobostype == 'link']
+#
+#        link_inertials = {}
+#        # append the link inertials for each link
+#        if link:
+#            inertials = sUtils.getImmediateChildren(link, phobostypes=('inertial',),
+#                                                    include_hidden=True)
+#            link_inertials = [inert for inert in inertials if 'inertial/inertia' in inert]
+#
+#        else:
+#            for link in linklist:
+#                linkname = link['link/name']
+#                inertials = sUtils.getImmediateChildren(link, phobostypes=('inertial',),
+#                                                        include_hidden=True)
+#                link_inertials[linkname] = [inert for inert in inertials
+#                                            if 'inertial/inertia' in inert]
+#
+#        return link_inertials
+#
+#    from_selected_only = BoolProperty(
+#        name='From selected objects', default=False,
+#        description='Include only the selected ' +
+#        'visual/collision object(s) into the link inertial(s).'
+#    )
+#
+#    autocalc = BoolProperty(
+#        name='Calculate automatically',
+#        default=True,
+#        description='Calculate inertial(s) automatically. Otherwise' +
+#                    ' create objects with empty inertia data.'
+#    )
+#
+#    overwrite = BoolProperty(
+#        name='Overwrite existing',
+#        default=True,
+#        description='Replace existing link inertial(s).'
+#    )
+#
+#    def invoke(self, context, event):
+#        return context.window_manager.invoke_props_dialog(self, width=500)
+#
+#    def draw(self, context):
+#        layout = self.layout
+#        layout.prop(self, "from_selected_only")
+#        layout.prop(self, "autocalc")
+#        layout.prop(self, "overwrite")
+#
+#    def execute(self, context):
+#        # keep the currently selected objects
+#        selected = context.selected_objects
+#        links = [obj for obj in selected if obj.phobostype == 'link']
+#        i = 1
+#        # calculate inertial objects for each link
+#        for link in links:
+#            # delete inertials which are overwritten
+#            if self.overwrite:
+#                link_inertials = self.getLinkInertials(context, link)
+#                sUtils.selectObjects(link_inertials, clear=True)
+#
+#                # remove deleted inertials from the selection
+#                for inert in link_inertials:
+#                    if inert in selected:
+#                        selected.remove(inert)
+#
+#                bpy.ops.object.delete()
+#
+#            # reselect the initial objects
+#            sUtils.selectObjects(selected, clear=True)
+#            # calculate the link inertials
+#            inertia.createLinkInertialObjects(link, self.autocalc, self.from_selected_only)
+#            display.setProgress(i/len(links))
+#            i += 1
+#        return {'FINISHED'}
+#
+#    @classmethod
+#    def poll(cls, context):
+#        # only enable button when there are links selected
+#        links = [obj for obj in context.selected_objects if obj.phobostype == 'link']
+#        return len(links) > 0
 
-class CreateLinkInertialOperator(Operator):
-    """Create inertial object(s) for link(s)"""
-    bl_idname = "phobos.create_link_inertials"
-    bl_label = "Create link inertia"
+
+class CreateInertialOperator(Operator):
+    """Create inertial object(s) from collision/visual objects of a link"""
+    bl_idname = "phobos.create_inertials"
+    bl_label = "Create inertial objects"
     bl_options = {'REGISTER', 'UNDO'}
 
-    def getLinkInertials(self, context, link=None):
-        """Returns all link inertials of the selected links (in the current
-        context) or of the specified link.
-
-        Args:
-          context: Blender context
-          link: the link of which to find the inertials (optional) (Default value = None)
-
-        Returns:
-          dictionary of links with list of Blender objects or just a list.
-
-        """
-        linklist = [obj for obj in context.selected_objects if obj.phobostype == 'link']
-
-        link_inertials = {}
-        # append the link inertials for each link
-        if link:
-            inertials = sUtils.getImmediateChildren(link, phobostypes=('inertial',),
-                                                    include_hidden=True)
-            link_inertials = [inert for inert in inertials if 'inertial/inertia' in inert]
-
-        else:
-            for link in linklist:
-                linkname = link['link/name']
-                inertials = sUtils.getImmediateChildren(link, phobostypes=('inertial',),
-                                                        include_hidden=True)
-                link_inertials[linkname] = [inert for inert in inertials
-                                            if 'inertial/inertia' in inert]
-
-        return link_inertials
-
-    from_selected_only = BoolProperty(
-        name='From selected objects', default=False,
-        description='Include only the selected ' +
-        'visual/collision object(s) into the link inertial(s).'
-    )
-
-    autocalc = BoolProperty(
-        name='Calculate automatically',
-        default=True,
-        description='Calculate inertial(s) automatically. Otherwise' +
-                    ' create objects with empty inertia data.'
-    )
-
-    overwrite = BoolProperty(
-        name='Overwrite existing',
-        default=True,
-        description='Replace existing link inertial(s).'
-    )
-
-    def invoke(self, context, event):
-        return context.window_manager.invoke_props_dialog(self, width=500)
-
-    def draw(self, context):
-        layout = self.layout
-        layout.prop(self, "from_selected_only")
-        layout.prop(self, "autocalc")
-        layout.prop(self, "overwrite")
-
-    def execute(self, context):
-        # keep the currently selected objects
-        selected = context.selected_objects
-        links = [obj for obj in selected if obj.phobostype == 'link']
-        i = 1
-        # calculate inertial objects for each link
-        for link in links:
-            # delete inertials which are overwritten
-            if self.overwrite:
-                link_inertials = self.getLinkInertials(context, link)
-                sUtils.selectObjects(link_inertials, clear=True)
-
-                # remove deleted inertials from the selection
-                for inert in link_inertials:
-                    if inert in selected:
-                        selected.remove(inert)
-
-                bpy.ops.object.delete()
-
-            # reselect the initial objects
-            sUtils.selectObjects(selected, clear=True)
-            # calculate the link inertials
-            inertia.createLinkInertialObjects(link, self.autocalc, self.from_selected_only)
-            display.setProgress(i/len(links))
-            i += 1
-        return {'FINISHED'}
-
-    @classmethod
-    def poll(cls, context):
-        # only enable button when there are links selected
-        links = [obj for obj in context.selected_objects if obj.phobostype == 'link']
-        return len(links) > 0
-
-
-class CreateHelperInertialOperator(Operator):
-    """Create helper inertial object(s) from collision/visual objects of a link"""
-    bl_idname = "phobos.create_helper_inertials"
-    bl_label = "Create helper inertials"
-    bl_options = {'REGISTER', 'UNDO'}
-
-    def getHelperInertials(self, context, link=None):
-        """Returns all helper inertials of the selected links (in the current
+    def getInertials(self, context, link=None):
+        """Returns all inertials of the selected links (in the current
         context) or of the specified link.
 
         Args:
@@ -635,21 +635,18 @@ class CreateHelperInertialOperator(Operator):
         if not link:
             links = [obj for obj in context.selected_objects if obj.phobostype == 'link']
 
-        helper_inertials = {}
+        inertials = {}
         # append the link inertials for each link
         if link:
             inertials = sUtils.getImmediateChildren(link, phobostypes=('inertial',),
                                                     include_hidden=True)
-            helper_inertials = [inert for inert in inertials if 'inertia' in inert]
 
         else:
             for link in links:
                 linkname = link['link/name']
                 inertials = sUtils.getImmediateChildren(link, phobostypes=('inertial',),
                                                         include_hidden=True)
-                helper_inertials[linkname] = [inert for inert in inertials if 'inertia' in inert]
-
-        return helper_inertials
+        return inertials
 
     autocalc = BoolProperty(
         name='Calculate automatically',
@@ -681,11 +678,11 @@ class CreateHelperInertialOperator(Operator):
         for link in links:
             # delete inertials which are overwritten
             if self.overwrite:
-                helper_inertials = self.getHelperInertials(context, link)
-                sUtils.selectObjects(helper_inertials, clear=True)
+                inertials = self.getInertials(context, link)
+                sUtils.selectObjects(inertials, clear=True)
 
                 # remove deleted inertials from the selection
-                for inert in helper_inertials:
+                for inert in inertials:
                     if inert in selected:
                         selected.remove(inert)
 
@@ -694,7 +691,7 @@ class CreateHelperInertialOperator(Operator):
             # reselect the initial objects
             sUtils.selectObjects(selected, clear=True)
 
-            inertia.createHelperInertialObjects(link, self.autocalc)
+            inertia.createInertialObjects(link, self.autocalc)
             display.setProgress(i/len(links))
             i += 1
 

--- a/phobos/phobosgui.py
+++ b/phobos/phobosgui.py
@@ -747,8 +747,8 @@ class PhobosModelPanel(bpy.types.Panel):
         mc1.label(text="Masses & Inertia", icon='PHYSICS')
         mc1.operator('phobos.calculate_mass')
         mc1.operator('phobos.set_mass')
-        mc1.operator('phobos.create_helper_inertials')
-        mc1.operator('phobos.create_link_inertials')
+        mc1.operator('phobos.create_inertials')
+        # mc1.operator('phobos.create_link_inertials')
         mc1.operator('phobos.edit_inertia')
 
 


### PR DESCRIPTION
The representation of inertial objects within phobos is not optimal. 

The helper and link inertials are both stored on the same layer and contain redundant information.

Since only the helper inertial data is needed to define several mass for one link, one can get rid of the link inertias and extract the information during the export.  

Furthermore a check for the inertia has been added to ensure the physical validity of the information. It checks if the inertia is positive definite, as needed for most rigid body simulations. Invalid inertias are textured red for a visual debugging.

Furthermore a small error within the matrix representation has been corrected.