### PR TITLE
Fixed editing.py to support sensor creation

### DIFF
--- a/phobos/operators/editing.py
+++ b/phobos/operators/editing.py
@@ -1578,7 +1578,10 @@ def addSensorFromYaml(name, sensortype):
                     # parse object dictionaries if "$selected_objects:..." syntax is found
                     annot = defs.definitions['sensors'][self.sensorType][custom_anno.name[2:]]
 
-                    annot = linkObjectLists(annot, selected_objs)
+                    if selected_objs:
+                        annot = linkObjectLists(annot, selected_objs)
+                    else:
+                        annot = linkObjectLists(annot, parent_obj)
 
                     annotation_objs.append(eUtils.addAnnotationObject(
                         sensor_obj, annot,


### PR DESCRIPTION
Error in sensor creation. If no link is selected, the operator gave
false parent_link;

If selected object is empty, the newly created link is passed to the
create Sensor function
