### PR TITLE
Updated inertia validation

### DIFF
--- a/config/definitions/defaultSensors.yml
+++ b/config/definitions/defaultSensors.yml
@@ -71,6 +71,7 @@ sensors:
         lasers: 32
         max_distance: 100.0
         draw_rays: True
+        opening_height: 0.698132
         horizontal_resolution: &(1/180)*math.pi&
         horizontal_offset: 0.0
         vertical_offset: 0.0

--- a/phobos/operators/editing.py
+++ b/phobos/operators/editing.py
@@ -183,6 +183,7 @@ class MoveToSceneOperator(Operator):
             for obj in moveobjs:
                 name = nUtils.getObjectName(obj)
 
+                # add phobostype/name to make sure the object keeps its name as single user
                 if obj.phobostype + '/name' not in obj:
                     obj[obj.phobostype + '/name'] = name
 
@@ -574,7 +575,14 @@ class SmoothenSurfaceOperator(Operator):
         objs = [obj for obj in context.selected_objects if obj.type == "MESH"]
         i = 1
         for obj in objs:
-            eUtils.smoothen_surface(obj)
+            context.scene.objects.active = obj
+            bpy.ops.object.mode_set(mode='EDIT')
+            bpy.ops.mesh.select_all(action='SELECT')
+            bpy.ops.mesh.normals_make_consistent()
+            bpy.ops.mesh.mark_sharp(clear=True)
+            bpy.ops.object.mode_set(mode='OBJECT')
+            bpy.ops.object.shade_smooth()
+            bpy.ops.object.modifier_add(type='EDGE_SPLIT')
             display.setProgress(i/len(context.selected_objects))
             i += 1
         return {'FINISHED'}
@@ -1572,10 +1580,6 @@ def addSensorFromYaml(name, sensortype):
                 if custom_anno.boolProp:
                     # parse object dictionaries if "$selected_objects:..." syntax is found
                     annot = defs.definitions['sensors'][self.sensorType][custom_anno.name[2:]]
-
-                    # include newly added parent link if not already selected
-                    if parent_obj not in selected_objs:
-                        selected_objs.append(parent_obj)
 
                     annot = linkObjectLists(annot, selected_objs)
 

--- a/phobos/utils/validation.py
+++ b/phobos/utils/validation.py
@@ -32,6 +32,7 @@ import bpy
 import phobos.defs as defs
 import phobos.utils.naming as nUtils
 from phobos.phoboslog import log
+from phobos.utils.io import getExpSettings
 
 
 checkMessages = {"NoObject": []}
@@ -544,30 +545,37 @@ def validateInertiaData(obj, *args, adjust=False):
         inertia = obj['inertial/inertia']
         mass = obj['inertial/mass']
 
-    # Check inertia vector for various properties
-    inertia = numpy.array(inertiaListToMatrix(inertia))
+    # Check inertia vector for various properties, round to export precision
+    inertia = numpy.around(numpy.array(inertiaListToMatrix(inertia)), decimals = getExpSettings().decimalPlaces)
     if any(element <= 0.0 for element in inertia.diagonal()):
+        element = 1e-3
         errors.append(ValidateMessage(
             "Negative semidefinite main diagonal in inertia data!",
             'WARNING',
             None if isinstance(obj, dict) else obj,
             None, {'log_info': "Diagonal: " + str(inertia.diagonal())}))
 
-    # Calculate the determinant if consistent
+
+    # Calculate the determinant if consistent, quick check
     if numpy.linalg.det(inertia) <= 0.0:
         errors.append(ValidateMessage(
-            "Negative semidefinite determinant in inertia data!",
+            "Negative semidefinite determinant in inertia data! Checking singular values.",
             'WARNING',
             None if isinstance(obj, dict) else obj,
             None, {'log_info': "Determinant: " + str(numpy.linalg.det(inertia))}))
 
-    # Calculate the eigenvalues if consistent
-    if any(element <= 0.0 for element in numpy.linalg.eigvals(inertia)):
-        errors.append(ValidateMessage(
-            "Negative semidefinite eigenvalues in inertia data!",
-            'WARNING',
-            None if isinstance(obj, dict) else obj,
-            None, {'log_info': "Eigenvalues: " + str(numpy.linalg.eigvals(inertia))}))
+        # Calculate the eigenvalues if not consistent
+        if any(element <= 0.0 for element in numpy.linalg.eigvals(inertia)):
+            # Apply singular value decomposition and correct the values
+            U,S,V = numpy.linalg.svd(inertia)
+            S[S<=0.0] = 1e-3
+            inertia = U*S*V
+            errors.append(ValidateMessage(
+                "Negative semidefinite eigenvalues in inertia data!",
+                'WARNING',
+                None if isinstance(obj, dict) else obj,
+                None, {'log_info': "Eigenvalues: " + str(numpy.linalg.eigvals(inertia))}))
+
 
     if mass <= 0.:
         errors.append(ValidateMessage(


### PR DESCRIPTION

## Description
The validation was not considering the rounding function of the export settings.
Furthermore, there was no real correction of the inertia tensor. 
This is now fixed by requiring a lower limit of the singular value.

In addition, the singular value decomposition is only used if the determinant is less or equal to zero.

## Related Issue
No open issue on github, but errors in robot model export.

## Motivation and Context
Enhance export quality and usability for non-pro users 

## How Has This Been Tested?
Reexported collapsing model

## Screenshots (if appropriate):
None

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
