### PR TITLE
Bugfix key error in parseLink

### DIFF
--- a/phobos/io/entities/urdf.py
+++ b/phobos/io/entities/urdf.py
@@ -700,7 +700,7 @@ def parseLink(link, urdffilepath):
         newlink[objtype] = {}
         for xmlelement in link.iter(objtype):
             # generate name for visual/collision representation
-            if 'name' not in xmlelement.attrib['name']:
+            if 'name' not in xmlelement.attrib.keys():
                 elementname = objtype + '_' + str(len(newlink[objtype])) + '_' + newlink['name']
             else:
                 elementname = xmlelement.attrib['name']


### PR DESCRIPTION
## Description
Fixing the KeyError in the urdf import script.

```
Traceback (most recent call last):
  File "/home/dfki.uni-bremen.de/hwiedemann/.config/blender/2.79/scripts/addons/phobos/operators/io.py", line 291, in execute
    model = entity_io.entity_types[self.entitytype]['import'](self.filepath)
  File "/home/dfki.uni-bremen.de/hwiedemann/.config/blender/2.79/scripts/addons/phobos/io/entities/urdf.py", line 628, in importUrdf
    links[link.attrib['name']] = parseLink(link, filepath)
  File "/home/dfki.uni-bremen.de/hwiedemann/.config/blender/2.79/scripts/addons/phobos/io/entities/urdf.py", line 703, in parseLink
    print(xmlelement.attrib)
KeyError: 'name'
```

