### PR TITLE
Adapt motor controller default PID gains

### DIFF
--- a/config/definitions/defaultControllers.yml
+++ b/config/definitions/defaultControllers.yml
@@ -40,9 +40,9 @@ controllers:
             categories:
                 - generic
                 - motor
-        p: 20.0
-        i: 1.0
-        d: 0.1
+        p: 70.0
+        i: 10.0
+        d: 0.005
     direct:
         general:
             type: direct


### PR DESCRIPTION
The old default values led to a wobbly motor behaviour in MARS.