### PR TITLE
Hotfix URDF import

### DIFF
--- a/phobos/io/entities/urdf.py
+++ b/phobos/io/entities/urdf.py
@@ -700,7 +700,7 @@ def parseLink(link, urdffilepath):
         newlink[objtype] = {}
         for xmlelement in link.iter(objtype):
             # generate name for visual/collision representation
-            if 'name' not in xmlelement.attrib['name']:
+            if 'name' not in xmlelement.attrib:
                 elementname = objtype + '_' + str(len(newlink[objtype])) + '_' + newlink['name']
             else:
                 elementname = xmlelement.attrib['name']


### PR DESCRIPTION
Wrong check of "name" key in urdf import / visual creation

## Description
Removed the wrong reference.

## Related Issue
Import of URDF files has been prone to error since not every visual has been uniquely named.

## Motivation and Context
Import of URDF files has been prone to error.

## How Has This Been Tested?
Import of several urdf files without unique naming.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
