### PR TITLE
Quickfix mesh collision creation

### DIFF
--- a/phobos/operators/editing.py
+++ b/phobos/operators/editing.py
@@ -1263,6 +1263,7 @@ class CreateCollisionObjects(Operator):
         visuals = []
         collisions = []
 
+
         # find all selected visual objects
         for obj in context.selected_objects:
             if obj.phobostype == "visual":
@@ -1334,16 +1335,35 @@ class CreateCollisionObjects(Operator):
                     phobostype='collision',
                 )
             elif self.property_colltype == 'mesh':
+                # FIXME Found error and made a quick 
+                # Copy object and data
+                #ob = bUtils.createPrimitive(
+                #    collname,
+                #    'box',
+                #    size,
+                #    player=defs.layerTypes['collision'],
+                #    pmaterial=materialname,
+                #    plocation=center,
+                #    protation=rotation_euler,
+                #    phobostype='collision',
+                #)
+                #ob.data.meshes = vis.data.meshes
+                
+
+                #current_scene.objects.link(ob)
+
                 # FIXME: simply turn this into object.duplicate?
-                bpy.ops.object.duplicate_move(
-                    OBJECT_OT_duplicate={"linked": False, "mode": 'TRANSLATION'},
-                    TRANSFORM_OT_translate={"value": (0, 0, 0)},
-                )
+                #ob = bpy.ops.object.duplicate_move(
+                #    OBJECT_OT_duplicate={"linked": False, "mode": 'TRANSLATION'},
+                #    TRANSFORM_OT_translate={"value": (0, 0, 0)},
+                #)
+                
                 # TODO: copy mesh? This was taken from pull request #102
-                # ob = blenderUtils.createPrimitive(collname, 'cylinder', (1,1,1),
-                #                                   defs.layerTypes['collision'], materialname, center,
-                #                                   rotation_euler)
-                # ob.data = vis.data
+                ob = bUtils.createPrimitive(collname, 'cylinder', (1,1,1),
+                                                 defs.layerTypes['collision'], materialname, center,
+                                                 rotation_euler)
+                ob.data = vis.data
+                
 
             # set properties of new collision object
             ob.phobostype = 'collision'

--- a/phobos/operators/editing.py
+++ b/phobos/operators/editing.py
@@ -1373,7 +1373,12 @@ class CreateCollisionObjects(Operator):
             # make collision object relative if visual object has a parent
             if vis.parent:
                 ob.select = True
-                bpy.ops.object.transform_apply(scale=True)
+                
+                # TODO This line created an error. Try to check all meshes
+                # which are related to each other and check for scale 1.0 or
+                # create new mesh object
+                #bpy.ops.object.transform_apply(scale=True)
+
                 # CHECK test whether mesh option does work
                 # this was taken from pull request #102
                 # try:


### PR DESCRIPTION
Due to scaling of meshes, the collision could not be created.

## Description
Removed ```scale = True``` argument for now. This is a quick fix and should be discussed properly.

## Related Issue
None

## Motivation and Context
Ability to quickly create mesh collisions for different needs, e.g. capability maps of robots with self-collision avoidance.

## How Has This Been Tested?
No proper testing right now.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
