### PR TITLE
Updated camera sensor definition of hud_pos to hud_idx.

### DIFF
--- a/config/definitions/defaultSensors.yml
+++ b/config/definitions/defaultSensors.yml
@@ -174,7 +174,7 @@ sensors:
         show_cam: true
         opening_width: 90
         opening_height: 90
-        hud_pos: 0
+        hud_idx: 0
         hud_width: 320
         hud_height: 240
         depth_image: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `hud_pos` property in the camera sensor definitions yml file was changed to `hud_idx`. The former is not recognized by MARS but the latter is.

## Related Issue
https://github.com/dfki-ric/phobos/issues/190

Note that the `hud_pos` property is also used for the scanning sonar sensor. Maybe this also needs to be updated: 
https://github.com/dfki-ric/phobos/blob/63682bd6b34d3d6fe9cd357aba5d5e0250dd3b72/config/definitions/defaultSensors.yml#L127

The hud position property for the scanning sonar sensor is left unchanged in this pull request.


## Motivation and Context
So that camera sensor huds can be positioned at different location within MARS.

## How Has This Been Tested?
This was tested by exporting a model with camera sensors and loading it on MARS.
Locations of the resulting camera sensor huds were checked against the hud index values.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project **(Not applicable: changes were in a config file)**.
- [ ] My change requires a change to the documentation **(Not applicable)**.
- [ ] I have updated the documentation accordingly **(Not applicable)**.
- [x] I have read the **CONTRIBUTING** document.
