### PR TITLE
Ensure blenderconfigpath exists before config copy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,7 @@ Debug information for Phobos:
 
     # install optional startup blend
     if startup_preset:
+        os.makedirs(blenderconfigpath, exist_ok=True)
         shutil.copy(path.join(phoboshome, 'config', 'startup.blend'), blenderconfigpath)
 
     # install config files


### PR DESCRIPTION
## Description
If the blender config path does not exist, startup.blend will instead be
copied as the `~/.config/blender/2.79b/config` file and not to a
directory.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
In an Ubuntu 16.04 VM running a fresh copy of blender 2.79b and the latest phobos source.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
