### PR TITLE
Update to support Blender 3.0.x keyword-only arguments signature

### DIFF
--- a/phobos/phobossystem.py
+++ b/phobos/phobossystem.py
@@ -58,7 +58,7 @@ def getConfigPath():
     Returns:
 
     """
-    configpath = path.normpath(path.join(bpy.utils.user_resource('SCRIPTS', "addons"), "phobos", "config"))
+    configpath = path.normpath(path.join(bpy.utils.user_resource(resource_type='SCRIPTS', path="addons"), "phobos", "config"))
     return configpath
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In Blender 3.xx, `bpy.utils.user_resource` is one of the APIs impacted by https://github.com/blender/blender/commit/f29a738e23ce487fc9ae759326fc3409b82f8b26. This pull request updates the API call to make sure keyword-only args are being used.

## How Has This Been Tested?

With the fix, Phobos gets correctly installed on 3.x beta, and seems to work just fine :)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
