### PR TITLE
Avoid spaces in link and joint names

### DIFF
--- a/phobos/blender/io/blender2phobos.py
+++ b/phobos/blender/io/blender2phobos.py
@@ -758,6 +758,11 @@ def deriveRepresentation(obj, logging=True, adjust=True):
     return repr_instance
 
 
+def fixLinkNames(objectlist):
+    for obj in objectlist:
+        if obj.phobostype == 'link':
+            obj.name = obj.name.replace(" ", "_")
+
 def deriveRobot(root, name='', objectlist=None):
     """
     Returns the phobos.core.Robot instance of a Phobos-Blender model.
@@ -790,6 +795,8 @@ def deriveRobot(root, name='', objectlist=None):
         objectlist = sUtils.getChildren(
             root, selected_only=ioUtils.getExpSettings().selectedOnly, include_hidden=False
         )
+
+    fixLinkNames(objectlist)
 
     # XMLVersion [TODO v2.1.0] Add matching constructor to phobos.core.Robot
     # TODO ErrorMessageWithBox(message="Link {} is not defined as a joint. Use Model Editing > Kinematics > Define Joint".format(obj.name))

--- a/phobos/blender/operators/editing.py
+++ b/phobos/blender/operators/editing.py
@@ -1514,6 +1514,8 @@ class DefineJointConstraintsOperator(Operator):
 
         """
         layout = self.layout
+        if self.name.replace(" ", "_") != self.name:
+            layout.label(text="Created as "+self.name.replace(" ", "_"))
         if len(context.selected_objects) == 1:
             layout.prop(self, "name")
         layout.prop(self, "joint_type", text="joint Type")
@@ -1613,7 +1615,7 @@ class DefineJointConstraintsOperator(Operator):
                 assert joint.parent is not None and joint.parent.phobostype == "link", \
                     f"You need to have a link parented to {joint.name} before you can create a joint"
                 if len(self.name) > 0:
-                    joint["joint/name"] = self.name
+                    joint["joint/name"] = self.name.replace(" ", "_")
                 jUtils.setJointConstraints(
                     joint=joint,
                     jointtype=self.joint_type,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replaces spaces with underscores in link and joint names
Renames links on export, joints when defining with the Define Joint operator

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
