### PR TITLE
Fix motor type ignored on export #332

### DIFF
--- a/phobos/blender/io/blender2phobos.py
+++ b/phobos/blender/io/blender2phobos.py
@@ -684,6 +684,8 @@ def deriveMotor(obj):
         annotations.pop("name")
     if "joint" in annotations:
         annotations.pop("joint")
+    if obj.get("motor/type", None):
+        annotations["type"] = obj.get("motor/type")
     return representation.Motor(
         name=obj.get("motor/name", obj.name),
         joint=obj.get("joint/name", obj.name),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently all motor types generate a JointPositionController. With this PR position motors generate a JointPositionController and force and velocity motors generate a JointController as intended.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
