### PR TITLE
representation.py: better assertion errors

### DIFF
--- a/phobos/io/representation.py
+++ b/phobos/io/representation.py
@@ -525,11 +525,13 @@ class Mesh(Representation, SmurfBase):
         self.material = material
         filepath = misc.sys_path(filepath if posix_path is None else posix_path)
         if mesh is not None:
-            assert meshname is not None and type(meshname) == str
+            if meshname is None or type(meshname) != str:
+                raise AssertionError(f"Invalid mesh name {meshname}.")
             self.original_mesh_name = meshname
             self._mesh_object = mesh
             self.input_type = str(type(mesh))[8:-2]  # handle: <class 'the type name'>
-            assert self.input_type in MESH_DATA_TYPES
+            if self.input_type not in MESH_DATA_TYPES:
+                raise AssertionError(f"The input type {self.input_type} of object {meshname} is not recognized.")
             self.input_file = None
             self.unique_name = meshname
             self._mesh_information = None


### PR DESCRIPTION
## Description
Replaced two simple `assert`s with detailed error messages about what's gone wrong.

## Related Issue
#353 

## Motivation and Context
I was working on a robot with 131 links and got an assertion error from representation.py, on this line:

    assert self.input_type in MESH_DATA_TYPES

The generic assertion error and call stack was not helpful for understanding what went wrong or which of the 131 links was causing the problem. I had to look at the source code to better understand the problem, and then replace the simple `assert` with a more detailed `AssertionError` so I would know which link was causing the error.

While I was at it, I also added a more detailed `AssertionError` for the case where the `meshname` is None or not a string.

## How Has This Been Tested?
I used the new `AssertionError` for `self.input_type` to identify which link in the robot was causing the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
