### PR TITLE
Fix inertia calculation

### DIFF
--- a/phobos/utils/inertia.py
+++ b/phobos/utils/inertia.py
@@ -126,7 +126,16 @@ def calculateMeshInertia(mass, data, scale=None):
             vertices = numpy.asarray([numpy.asarray(scale * v.co) for v in data.vertices])
             prev_mode = bpy.context.mode
             bpy.ops.object.mode_set(mode='EDIT')
+            # store selected vertices
+            selected_vertices = [v.index for v in data.vertices if v.select]
+            # select all vertices for conversion
+            bpy.ops.mesh.select_all(action='SELECT')
             bpy.ops.mesh.quads_convert_to_tris(quad_method='FIXED')
+            # reset selected vertices
+            bpy.ops.mesh.select_all(action='DESELECT')
+            bpy.ops.object.mode_set(mode='OBJECT')
+            for i in selected_vertices:
+                data.vertices[i].select = True
             bpy.ops.object.mode_set(mode=prev_mode)
             faces = [[v for v in p.vertices] for p in data.polygons]
             triangle_normals = numpy.asarray([t.normal for t in data.polygons])


### PR DESCRIPTION
Fixes inertia calculation for meshes with quads that are not selected.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#351 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To calculate the inertia of a mesh all quads are cut into triangles. In case the user deselected some faces in edit mode the cuts are only applied to selected faces. Thus the calculation fails. This PR selects all vertices prior to cutting the quads and reapplies the previously selected vertices.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by author of #351 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
