### PR TITLE
Fix merging inertials with mass 0

### DIFF
--- a/phobos/blender/model/inertia.py
+++ b/phobos/blender/model/inertia.py
@@ -201,7 +201,13 @@ def combine_com_3x3(objects):
     for obj in objects:
         combined_com = combined_com + obj.matrix_local.translation * obj['mass']
         combined_mass += obj['mass']
-    combined_com = combined_com / combined_mass
+    if combined_mass != 0:
+        combined_com = combined_com / combined_mass
+    else:
+        combined_com = mathutils.Vector((0.0,) * 3)
+        for obj in objects:
+            combined_com = combined_com + obj.matrix_local.translation
+        log(message=f"Inertial {objects[0].name} exported with mass 0")
     log("  Combined center of mass: " + str(combined_com), 'DEBUG')
     return combined_mass, combined_com
 

--- a/phobos/blender/model/inertia.py
+++ b/phobos/blender/model/inertia.py
@@ -205,9 +205,31 @@ def combine_com_3x3(objects):
         combined_com = combined_com / combined_mass
     else:
         combined_com = mathutils.Vector((0.0,) * 3)
+        combined_volume = 0
         for obj in objects:
-            combined_com = combined_com + obj.matrix_local.translation
-        log(message=f"Inertial {objects[0].name} exported with mass 0")
+            # calculate volume
+            mesh = representation.Mesh(
+                mesh=obj.data.copy(),
+                meshname=obj.data.name
+            )
+            volume, _ = mesh.approx_volume_and_com()
+            center = obj.matrix_local.translation
+
+            combined_volume += volume
+            combined_com = combined_com + center * volume
+        combined_com = combined_com / combined_volume
+
+        if len(objects) > 1:
+            all_objects = ""
+            for i in range(len(objects)):
+                obj = objects[i]
+                if i == 0:
+                    all_objects += obj.name
+                elif i == len(objects)-1:
+                    all_objects += " and "+obj.name
+                else:
+                    all_objects += ", "+obj.name
+            log(message=f"Mass of {all_objects} totals 0. Weighing by volume", level='INFO')
     log("  Combined center of mass: " + str(combined_com), 'DEBUG')
     return combined_mass, combined_com
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On export we calculate the center of mass of all inertials of an object. This fails if their mass totals 0. In this case this PR uses their center as center of mass.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#349 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
