### PR TITLE
Fix div by zero error

### DIFF
--- a/phobos/blender/model/inertia.py
+++ b/phobos/blender/model/inertia.py
@@ -201,6 +201,9 @@ def combine_com_3x3(objects):
     for obj in objects:
         combined_com = combined_com + obj.matrix_local.translation * obj['mass']
         combined_mass += obj['mass']
+    if combined_mass == 0:
+        log("No mass found in objects...", 'DEBUG')
+        return 0.0, mathutils.Vector((0.0,) * 3)
     combined_com = combined_com / combined_mass
     log("  Combined center of mass: " + str(combined_com), 'DEBUG')
     return combined_mass, combined_com


### PR DESCRIPTION
URDF allows for links without mass. This is for example needed for ball joints or spherical joints, where 2 axes cross in a single point. Phobos cannot handle this case so far.

## Description
Just catch the case that total_mass is zero

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
